### PR TITLE
Exclude selected templates

### DIFF
--- a/PageRenameOptions.module
+++ b/PageRenameOptions.module
@@ -45,6 +45,7 @@ class PageRenameOptions extends WireData implements Module, ConfigurableModule {
             return array(
                 "exemptRoles" => array(),
                 "exemptPages" => array(),
+                "exemptTemplates" => array(),
                 "initialDifference" => "",
                 "preventManualChanges" => "",
                 "liveChanges" => ""
@@ -76,6 +77,9 @@ class PageRenameOptions extends WireData implements Module, ConfigurableModule {
 
         //escape if page is exempt
         if(count($this->data['exemptPages']) !== 0 && in_array($p->id, $this->data['exemptPages'])) return;
+
+        //escape if template is exempt
+        if(count($this->data['exemptTemplates']) !== 0 && in_array($p->template->id, $this->data['exemptTemplates'])) return;
 
         // $p->id check is because it is not available for ProcessPageAdd
         if($p->id && $p->template->flags & Template::flagSystem) return; // exclude system templates eg. users etc
@@ -162,7 +166,7 @@ class PageRenameOptions extends WireData implements Module, ConfigurableModule {
         $f = wire('modules')->get('InputfieldAsmSelect');
         $f->attr('name+id', 'exemptRoles');
         $f->label = __('Exempt Roles');
-        $f->columnWidth = 50;
+        $f->columnWidth = 33;
         $f->description = __("The selected roles will not be subject to any of the rules below.\nThe name will change automatically with the title, but they will be able to manually edit the page name as desired.");
         $f->setAsmSelectOption('sortable', false);
         // populate with all available templates
@@ -170,10 +174,21 @@ class PageRenameOptions extends WireData implements Module, ConfigurableModule {
         if(isset($data['exemptRoles'])) $f->value = $data['exemptRoles'];
         $wrapper->add($f);
 
+        $f = wire('modules')->get('InputfieldAsmSelect');
+        $f->attr('name+id', 'exemptTemplates');
+        $f->label = __('Exempt Templates');
+        $f->columnWidth = 34;
+        $f->description = __("Selected templates are excluded from the actions of this module. ");
+        $f->setAsmSelectOption('sortable', false);
+        // populate with all available templates
+        foreach(wire('templates') as $t) $f->addOption($t->id,$t->name);
+        if(isset($data['exemptTemplates'])) $f->value = $data['exemptTemplates'];
+        $wrapper->add($f);
+
         $f = wire('modules')->get('InputfieldPageListSelectMultiple');
         $f->attr('name+id', 'exemptPages');
         $f->label = __('Excluded Pages');
-        $f->columnWidth = 50;
+        $f->columnWidth = 33;
         $f->description = __("Pages that are excluded from the actions of this module. Changing the titles of selected pages will behave as though this module is not installed. For multi-language sites it is recommended to select the site's homepage.");
         if(isset($data['exemptPages'])) $f->value = $data['exemptPages'];
         $wrapper->add($f);


### PR DESCRIPTION
Add the possibility to exclude selected templates (e.g, PageTable templates) from the page rename process
